### PR TITLE
wotlk page path instead of subdomain

### DIFF
--- a/src/Common.tsx
+++ b/src/Common.tsx
@@ -635,5 +635,5 @@ export function getAllocatedTalentsPointsInTree(
 export function getBaseWowheadUrl(language: string): string {
   return `https://${
     Languages.find(e => e.Iso === language)?.WowheadPrefix || ''
-  }wotlk.wowhead.com`
+  }wowhead.com/wotlk`
 }


### PR DESCRIPTION
## What does this PR do
- lookup wowhead wotlk as path instead of sub domain.

## Motivation
- Wowhead decided to go with path based instead of having sub domain like classic and tbc (e.g. tbc.wowhead.com) , for now it's wowhead.com/wotlk (confirmed by Rokman from wowhead.)
-  https://github.com/Kristoferhh/WarlockSimulatorWOTLK/issues/12