### PR TITLE
fix: apply with prefix empty talents

### DIFF
--- a/src/components/TalentTrees.tsx
+++ b/src/components/TalentTrees.tsx
@@ -34,8 +34,13 @@ export default function TalentTrees() {
   function applyTalentTemplate(talentTemplate: {
     [key in TalentName]?: number
   }) {
+    var emptyTalents: { [key: string]: number } = {}
+    for (const talentKey in TalentName) {
+      emptyTalents[talentKey] = 0
+    }
+
     let newSelectedTalents: TalentStore = JSON.parse(
-      JSON.stringify(playerState.Talents)
+      JSON.stringify(emptyTalents)
     )
 
     for (const [talentKey, points] of Object.entries(talentTemplate)) {


### PR DESCRIPTION
## What does this PR do
- starts with empty talents as base talents before applying new presets

## Motivation
-  https://github.com/Kristoferhh/WarlockSimulatorWOTLK/issues/11