### PR TITLE
fix: display chosen unique weapons

### DIFF
--- a/src/Common.tsx
+++ b/src/Common.tsx
@@ -242,7 +242,7 @@ export function getItemTableItems(
       e.ItemSlot === itemSlot &&
       sources.includes(e.Phase) &&
       (!hiddenItems.includes(e.Id) || hidingItems) &&
-      (!e.Unique || secondRingOrTrinket !== e.Id)
+      ((!e.Unique || secondRingOrTrinket !== e.Id) || (e.Unique && e.ItemSlot === ItemSlot.Weapon))
     )
   }).sort((a, b) => {
     // If it's a multi-item simulation then sort by phase from highest to lowest, otherwise sort by the saved dps or by phase as backup
@@ -468,10 +468,10 @@ export function GetTalentsStats(
     demonicEmbraceAmount === 1
       ? 1.04
       : demonicEmbraceAmount === 2
-      ? 1.07
-      : demonicEmbraceAmount === 3
-      ? 1.1
-      : 1
+        ? 1.07
+        : demonicEmbraceAmount === 3
+          ? 1.1
+          : 1
   )
   AddOrMultiplyStat(
     statsObj || stats,
@@ -487,8 +487,8 @@ export function GetTalentsStats(
     statsObj || stats,
     Stat.SpellPower,
     Auras.find(x => x.Id === AuraId.FelArmor)!.Stats![Stat.SpellPower]! *
-      0.1 *
-      talents['Demonic Aegis'] || 0
+    0.1 *
+    talents['Demonic Aegis'] || 0
   )
 
   if (
@@ -605,7 +605,7 @@ export function getPlayerHitPercent(
 ): number {
   let hitPercent =
     (hitRating || getPlayerHitRating(playerState)) /
-      StatConstant.HitRatingPerPercent +
+    StatConstant.HitRatingPerPercent +
     Object.values(playerState.Stats)
       .map(obj => obj[Stat.HitChance] || 0)
       .reduce((a, b) => a + b)
@@ -633,7 +633,6 @@ export function getAllocatedTalentsPointsInTree(
 }
 
 export function getBaseWowheadUrl(language: string): string {
-  return `https://${
-    Languages.find(e => e.Iso === language)?.WowheadPrefix || ''
-  }wowhead.com/wotlk`
+  return `https://${Languages.find(e => e.Iso === language)?.WowheadPrefix || ''
+    }wowhead.com/wotlk`
 }


### PR DESCRIPTION
## What this PR do
filter items and keeps unique weapons displayed if chosen

## Motivation 
https://github.com/Kristoferhh/WarlockSimulatorWOTLK/issues/15

right now unique items that are chosen will be filtered because of the rings and trinkets, I don't think this is the perfect solution but more of a patch solution for weapons, this may be re-introduced if there are unique items which are not weapons/trinkets/rings.

@Kristoferhh Another option is to remove unique from the relevant weapons in Items.tsx, but long term people may continue use unique because that's what WoWhead says, I think adding this filter change may be a better change.

